### PR TITLE
Improve Dgml diagnostics

### DIFF
--- a/sizoscope/DiffForm.cs
+++ b/sizoscope/DiffForm.cs
@@ -42,6 +42,18 @@ namespace sizoscope
 
         private void NodeMouseDoubleClickCommon(TreeNode treeNode, MstatData data)
         {
+            if (!data.DgmlSupported)
+            {
+                MessageBox.Show("Dependency graph information is only available in .NET 8 Preview 4 or later.");
+                return;
+            }
+
+            if (!data.DgmlAvailable)
+            {
+                MessageBox.Show("Dependency graph data was not found. Ensure IlcGenerateDgmlFile=true is specified.");
+                return;
+            }
+
             int? id = treeNode.Tag switch
             {
                 MstatTypeDefinition typedef => typedef.NodeId,
@@ -55,7 +67,7 @@ namespace sizoscope
             {
                 if (id.Value < 0)
                 {
-                    MessageBox.Show("Dependency graph information is only available in .NET 8 Preview 4 or later.");
+                    MessageBox.Show("This node was not used directly and is included for display purposes only. Try analyzing sub nodes.");
                     return;
                 }
 

--- a/sizoscope/MainForm.cs
+++ b/sizoscope/MainForm.cs
@@ -272,6 +272,18 @@ namespace sizoscope
 
         private void _tree_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
         {
+            if (!_data.DgmlSupported)
+            {
+                MessageBox.Show("Dependency graph information is only available in .NET 8 Preview 4 or later.");
+                return;
+            }
+
+            if (!_data.DgmlAvailable)
+            {
+                MessageBox.Show("Dependency graph data was not found. Ensure IlcGenerateDgmlFile=true is specified.");
+                return;
+            }
+
             int? id = e.Node.Tag switch
             {
                 MstatTypeDefinition typedef => typedef.NodeId,
@@ -285,7 +297,7 @@ namespace sizoscope
             {
                 if (id.Value < 0)
                 {
-                    MessageBox.Show("Dependency graph information is only available in .NET 8 Preview 4 or later.");
+                    MessageBox.Show("This node was not used directly and is included for display purposes only. Try analyzing sub nodes.");
                     return;
                 }
 

--- a/sizoscope/MstatData.Graph.cs
+++ b/sizoscope/MstatData.Graph.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 
 partial class MstatData
 {
     private Dictionary<string, Node> _nameToNode;
 
+    public bool DgmlSupported => _version.Major >= 2;
+    public bool DgmlAvailable => DgmlSupported && _nameToNode != null;
+
     public Node GetNodeForId(int id)
     {
-        if (_version.Major < 2 || _nameToNode == null)
+        if (!DgmlAvailable)
             return null;
 
         PEMemoryBlock nameMap = _peReader.GetSectionData(".names");


### PR DESCRIPTION
I was confusingly getting the error message `Dependency graph information is only available in .NET 8 Preview 4 or later.` when clicking on certain type symbols like `System.BigInteger` which was due to the `MstatTypeSpecification` having a `NodeId` of `-2`.

After debugging of the code i've figured this is because `ParseTypes` does not list `System.BigInteger` and it's only later initialized when the methods of `System.BigInteger` are populated from `ParseMethods`.

Adjusted the error messages to clarify what's going on.